### PR TITLE
Build project with vite and fix statistics error

### DIFF
--- a/utils/statistics.ts
+++ b/utils/statistics.ts
@@ -812,6 +812,7 @@ export async function saveStatisticsData<T>(
   data: T,
   retryCount: number = 0
 ): Promise<boolean> {
+  try {
     // 테이블별로 올바른 제약조건 사용
     let conflictColumns: string;
     
@@ -840,8 +841,38 @@ export async function saveStatisticsData<T>(
       default:
         conflictColumns = 'user_id,date';
     }
+
+    // 데이터를 upsert로 저장
+    const { error } = await supabase
+      .from(tableName)
+      .upsert(data);
+
+    if (error) {
+      console.error(`${tableName} 저장 실패:`, error);
+      
+      // 재시도 로직 (최대 3회)
+      if (retryCount < 3) {
+        console.log(`${tableName} 저장 재시도 (${retryCount + 1}/3)`);
+        await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+        return await saveStatisticsData(tableName, data, retryCount + 1);
+      }
+      
+      return false;
     }
-  });
+
+    return true;
+  } catch (error) {
+    console.error(`${tableName} 저장 중 예외 발생:`, error);
+    
+    // 재시도 로직 (최대 3회)
+    if (retryCount < 3) {
+      console.log(`${tableName} 저장 재시도 (${retryCount + 1}/3)`);
+      await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+      return await saveStatisticsData(tableName, data, retryCount + 1);
+    }
+    
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
Complete `saveStatisticsData` function in `utils/statistics.ts` to fix build error and enable data upsert with retry logic.

The `saveStatisticsData` function was incomplete, missing the actual database upsert operation and retry logic, which caused a syntax error during the build process. This PR adds the missing Supabase upsert call, error handling, and retry mechanism, resolving the build failure and ensuring the function correctly saves statistics data.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbcffda4-f4fa-41f3-af37-b4146bc0f002">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbcffda4-f4fa-41f3-af37-b4146bc0f002">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>