### PR TITLE
Fix statistics.ts syntax error

### DIFF
--- a/utils/statistics.ts
+++ b/utils/statistics.ts
@@ -841,13 +841,25 @@ export async function saveStatisticsData<T>(
       default:
         conflictColumns = 'user_id,date';
     }
-      }
-      
-      return false;
+
+    // 데이터를 Supabase에 upsert
+    const { error } = await supabase
+      .from(tableName)
+      .upsert(data, { onConflict: conflictColumns });
+
+    if (error) {
+      throw error;
     }
 
     return true;
   } catch (error) {
+    console.error(`통계 데이터 저장 실패 (${tableName}):`, error);
+    
+    // 재시도 로직 (최대 3회)
+    if (retryCount < 3) {
+      console.log(`재시도 중... (${retryCount + 1}/3)`);
+      await new Promise(resolve => setTimeout(resolve, 1000 * (retryCount + 1)));
+      return await saveStatisticsData(tableName, data, retryCount + 1);
     }
     
     return false;


### PR DESCRIPTION
Fix build error by correcting malformed syntax and adding missing database upsert logic in `saveStatisticsData`.

The `saveStatisticsData` function had an incomplete `try-catch` block and was missing the actual Supabase upsert operation, leading to a build error "Expected 'finally' but found 'return'". This PR completes the function by adding the upsert call, proper error handling with retry logic, and correcting the brace structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-776ef199-e1cd-4ed2-80da-35e008f0d3a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-776ef199-e1cd-4ed2-80da-35e008f0d3a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>