### PR TITLE
Fix undefined sevenDays property error

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -947,10 +947,10 @@ function AppProvider({ children }: { children: ReactNode }) {
       }
 
       // 알림 설정 통계
-      if (sub.notifications.sevenDays) notificationStats.sevenDays++;
-      if (sub.notifications.threeDays) notificationStats.threeDays++;
-      if (sub.notifications.sameDay) notificationStats.sameDay++;
-      if (sub.notifications.sevenDays || sub.notifications.threeDays || sub.notifications.sameDay) {
+      if (sub.notifications?.sevenDays) notificationStats.sevenDays++;
+      if (sub.notifications?.threeDays) notificationStats.threeDays++;
+      if (sub.notifications?.sameDay) notificationStats.sameDay++;
+      if (sub.notifications?.sevenDays || sub.notifications?.threeDays || sub.notifications?.sameDay) {
         notificationStats.totalWithNotifications++;
       }
 

--- a/components/Notifications.tsx
+++ b/components/Notifications.tsx
@@ -147,7 +147,7 @@ export function Notifications() {
             const daysUntilPayment = Math.ceil((paymentDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
             
             // 7일 전 알림
-            if (daysUntilPayment === 7 && sub.notifications.sevenDays) {
+            if (daysUntilPayment === 7 && sub.notifications?.sevenDays) {
               new Notification(`${sub.serviceName} 결제 예정`, {
                 body: `7일 후 ${sub.serviceName} 결제가 예정되어 있습니다. (${formatCurrency(sub.amount, sub.currency)})`,
                 icon: '/favicon.ico',
@@ -157,7 +157,7 @@ export function Notifications() {
             }
             
             // 3일 전 알림
-            if (daysUntilPayment === 3 && sub.notifications.threeDays) {
+            if (daysUntilPayment === 3 && sub.notifications?.threeDays) {
               new Notification(`${sub.serviceName} 결제 예정`, {
                 body: `3일 후 ${sub.serviceName} 결제가 예정되어 있습니다. (${formatCurrency(sub.amount, sub.currency)})`,
                 icon: '/favicon.ico',
@@ -167,7 +167,7 @@ export function Notifications() {
             }
             
             // 당일 알림
-            if (daysUntilPayment === 0 && sub.notifications.sameDay) {
+            if (daysUntilPayment === 0 && sub.notifications?.sameDay) {
               new Notification(`${sub.serviceName} 결제일`, {
                 body: `오늘 ${sub.serviceName} 결제일입니다. (${formatCurrency(sub.amount, sub.currency)})`,
                 icon: '/favicon.ico',
@@ -186,7 +186,7 @@ export function Notifications() {
           const amount = sub.currency === 'USD' ? sub.amount * settings.exchangeRate : sub.amount;
 
           // 7-day reminder
-          if (daysUntilPayment <= 7 && daysUntilPayment > 3 && sub.notifications.sevenDays) {
+          if (daysUntilPayment <= 7 && daysUntilPayment > 3 && sub.notifications?.sevenDays) {
             generatedNotifications.push({
               id: `${sub.id}-7days-${paymentDate.getTime()}`,
               type: 'payment',
@@ -207,7 +207,7 @@ export function Notifications() {
           }
           
           // 3-day reminder
-          if (daysUntilPayment <= 3 && daysUntilPayment > 0 && sub.notifications.threeDays) {
+          if (daysUntilPayment <= 3 && daysUntilPayment > 0 && sub.notifications?.threeDays) {
             generatedNotifications.push({
               id: `${sub.id}-3days-${paymentDate.getTime()}`,
               type: 'payment',

--- a/components/Notifications.tsx
+++ b/components/Notifications.tsx
@@ -228,7 +228,7 @@ export function Notifications() {
           }
           
           // Same-day reminder
-          if (daysUntilPayment === 0 && sub.notifications.sameDay) {
+          if (daysUntilPayment === 0 && sub.notifications?.sameDay) {
             generatedNotifications.push({
               id: `${sub.id}-today-${paymentDate.getTime()}`,
               type: 'payment',


### PR DESCRIPTION
Add optional chaining to `notifications` property access to prevent `TypeError`.

The `TypeError: Cannot read properties of undefined (reading 'sevenDays')` occurred because `sub.notifications` could be undefined, leading to attempts to access its properties directly. This change ensures safe access by using `?.`.

---
<a href="https://cursor.com/background-agent?bcId=bc-74fce9ad-d678-4ad1-a227-ff800541b73d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74fce9ad-d678-4ad1-a227-ff800541b73d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>