### PR TITLE
Check for insecure database views

### DIFF
--- a/supabase/SECURITY_FIXES.md
+++ b/supabase/SECURITY_FIXES.md
@@ -1,0 +1,127 @@
+# 보안 문제 해결 가이드
+
+## 발견된 보안 문제들
+
+Supabase Database Linter에서 다음과 같은 보안 문제들이 발견되었습니다:
+
+### 1. `auth_users_exposed` 오류
+- **문제**: `user_subscription_summary` 뷰가 `auth.users` 데이터를 익명(anon) 역할에 노출
+- **위험도**: ERROR
+- **영향**: 사용자 데이터 보안 침해 가능성
+
+### 2. `security_definer_view` 오류들
+- **문제**: `user_subscription_stats`와 `user_subscription_summary` 뷰가 SECURITY DEFINER로 정의됨
+- **위험도**: ERROR
+- **영향**: 뷰 생성자의 권한으로 실행되어 RLS 정책 우회 가능성
+
+## 해결 방법
+
+### 1. 즉시 적용할 수정사항
+
+`fix-security-issues.sql` 파일을 Supabase SQL Editor에서 실행하세요:
+
+```sql
+-- Supabase Dashboard > SQL Editor에서 실행
+\i supabase/fix-security-issues.sql
+```
+
+### 2. 적용된 수정사항
+
+#### A. 기존 뷰 삭제 및 재생성
+- `user_subscription_summary` 뷰 삭제 후 보안 강화된 버전으로 재생성
+- `user_subscription_stats` 뷰에서 SECURITY DEFINER 제거
+
+#### B. 권한 수정
+- 익명(anon) 역할의 뷰 접근 권한 완전 제거
+- 인증된(authenticated) 역할에만 SELECT 권한 부여
+
+#### C. 안전한 함수 생성
+- `get_my_subscription_stats()`: 현재 사용자의 통계만 반환
+- `get_my_subscription_summary()`: 현재 사용자의 요약 정보만 반환
+
+### 3. 새로운 보안 모델
+
+#### 기존 (문제가 있었던) 접근 방식:
+```sql
+-- 위험: 모든 사용자 데이터에 접근 가능
+SELECT * FROM user_subscription_stats;
+```
+
+#### 새로운 (안전한) 접근 방식:
+```sql
+-- 안전: 현재 사용자의 데이터만 반환
+SELECT * FROM get_my_subscription_stats();
+SELECT * FROM get_my_subscription_summary();
+```
+
+## 애플리케이션 코드 수정 필요사항
+
+### 기존 코드 (수정 필요):
+```typescript
+// ❌ 위험한 방식 - 더 이상 작동하지 않음
+const { data } = await supabase
+  .from('user_subscription_stats')
+  .select('*')
+  .eq('user_id', user.id);
+```
+
+### 새로운 코드 (권장):
+```typescript
+// ✅ 안전한 방식
+const { data } = await supabase.rpc('get_my_subscription_stats');
+const { data: summary } = await supabase.rpc('get_my_subscription_summary');
+```
+
+## 보안 강화 효과
+
+### 1. auth.users 데이터 보호
+- ✅ `auth.users` 테이블의 민감한 정보 노출 차단
+- ✅ 익명 사용자의 사용자 데이터 접근 완전 차단
+
+### 2. Row Level Security (RLS) 강화
+- ✅ SECURITY DEFINER 제거로 RLS 정책 완전 적용
+- ✅ 각 사용자는 자신의 데이터만 접근 가능
+
+### 3. 최소 권한 원칙 적용
+- ✅ 인증된 사용자만 뷰 접근 가능
+- ✅ 함수를 통한 제어된 데이터 접근
+
+## 검증 방법
+
+### 1. Database Linter 재실행
+수정 후 Supabase Dashboard에서 Database Linter를 다시 실행하여 오류가 해결되었는지 확인하세요.
+
+### 2. 권한 테스트
+```sql
+-- 익명 사용자로 테스트 (실패해야 함)
+SET ROLE anon;
+SELECT * FROM user_subscription_stats; -- 오류 발생해야 함
+
+-- 인증된 사용자로 테스트 (성공해야 함)
+SET ROLE authenticated;
+SELECT * FROM get_my_subscription_stats(); -- 성공해야 함
+```
+
+### 3. 애플리케이션 테스트
+- 로그인하지 않은 상태에서 통계 데이터 접근 시도 (실패해야 함)
+- 로그인한 상태에서 자신의 통계 데이터 접근 (성공해야 함)
+- 다른 사용자의 데이터 접근 시도 (실패해야 함)
+
+## 추가 권장사항
+
+### 1. 정기적인 보안 점검
+- 매월 Database Linter 실행
+- 새로운 뷰나 함수 생성 시 보안 검토
+
+### 2. 개발 가이드라인
+- 새 뷰 생성 시 SECURITY DEFINER 사용 금지
+- auth.users 테이블 직접 참조 금지
+- 모든 데이터 접근에 RLS 정책 적용 확인
+
+### 3. 모니터링
+- 비정상적인 데이터 접근 패턴 모니터링
+- 권한 변경 사항 로그 관리
+
+## 문의사항
+
+보안 수정 사항 관련 문의사항이 있으시면 개발팀에 문의해주세요.

--- a/supabase/database-schema.sql
+++ b/supabase/database-schema.sql
@@ -393,7 +393,8 @@ CREATE TRIGGER update_user_preferences_updated_at
 -- 11. 뷰 생성
 -- =====================================================
 
--- 사용자별 구독 통계 뷰
+-- 사용자별 구독 통계 뷰 (보안 강화 버전)
+-- SECURITY DEFINER 제거하고 RLS에 의존
 CREATE OR REPLACE VIEW user_subscription_stats AS
 SELECT 
   user_id,

--- a/supabase/fix-security-issues.sql
+++ b/supabase/fix-security-issues.sql
@@ -1,0 +1,202 @@
+-- =====================================================
+-- 보안 문제 해결 스크립트
+-- Supabase Database Linter에서 발견된 보안 문제들을 수정
+-- =====================================================
+
+-- =====================================================
+-- 1. 기존 문제가 있는 뷰들 삭제
+-- =====================================================
+
+-- 기존 user_subscription_summary 뷰 삭제 (SECURITY DEFINER 및 auth.users 노출 문제)
+DROP VIEW IF EXISTS public.user_subscription_summary;
+
+-- 기존 user_subscription_stats 뷰 삭제 (SECURITY DEFINER 문제)
+DROP VIEW IF EXISTS public.user_subscription_stats;
+
+-- =====================================================
+-- 2. 보안이 강화된 뷰들 재생성
+-- =====================================================
+
+-- user_subscription_stats 뷰 재생성 (SECURITY DEFINER 제거)
+-- 이 뷰는 auth.users 테이블을 직접 참조하지 않고 user_id만 사용
+CREATE OR REPLACE VIEW public.user_subscription_stats AS
+SELECT 
+  s.user_id,
+  COUNT(*) as total_subscriptions,
+  COUNT(CASE WHEN s.status = 'active' THEN 1 END) as active_subscriptions,
+  COUNT(CASE WHEN s.status = 'paused' THEN 1 END) as paused_subscriptions,
+  COUNT(CASE WHEN s.status = 'cancelled' THEN 1 END) as cancelled_subscriptions,
+  SUM(CASE WHEN s.currency = 'USD' THEN s.amount * 1300 ELSE s.amount END) as total_monthly_krw,
+  MAX(s.created_at) as last_updated
+FROM subscriptions s
+GROUP BY s.user_id;
+
+-- user_subscription_summary 뷰 생성 (보안 강화된 버전)
+-- auth.users의 민감한 정보를 노출하지 않고, 필요한 통계 정보만 제공
+CREATE OR REPLACE VIEW public.user_subscription_summary AS
+SELECT 
+  s.user_id,
+  COUNT(*) as subscription_count,
+  COUNT(CASE WHEN s.status = 'active' THEN 1 END) as active_count,
+  COUNT(CASE WHEN s.status = 'paused' THEN 1 END) as paused_count,
+  COUNT(CASE WHEN s.status = 'cancelled' THEN 1 END) as cancelled_count,
+  
+  -- 금액 통계 (한화 기준)
+  SUM(CASE 
+    WHEN s.currency = 'USD' THEN s.amount * 1300 
+    ELSE s.amount 
+  END) as total_monthly_krw,
+  
+  AVG(CASE 
+    WHEN s.currency = 'USD' THEN s.amount * 1300 
+    ELSE s.amount 
+  END) as avg_monthly_krw,
+  
+  -- 카테고리별 통계
+  COUNT(DISTINCT s.category) as category_count,
+  
+  -- 결제 주기별 통계
+  COUNT(CASE WHEN s.payment_cycle = 'monthly' THEN 1 END) as monthly_subscriptions,
+  COUNT(CASE WHEN s.payment_cycle = 'yearly' THEN 1 END) as yearly_subscriptions,
+  COUNT(CASE WHEN s.payment_cycle = 'onetime' THEN 1 END) as onetime_subscriptions,
+  
+  -- 통화별 통계
+  COUNT(CASE WHEN s.currency = 'KRW' THEN 1 END) as krw_subscriptions,
+  COUNT(CASE WHEN s.currency = 'USD' THEN 1 END) as usd_subscriptions,
+  
+  -- 시간 정보
+  MIN(s.created_at) as first_subscription_date,
+  MAX(s.created_at) as last_subscription_date,
+  MAX(s.updated_at) as last_updated
+  
+FROM subscriptions s
+GROUP BY s.user_id;
+
+-- =====================================================
+-- 3. 뷰에 대한 RLS 정책 설정
+-- =====================================================
+
+-- user_subscription_stats 뷰에 대한 RLS 활성화
+-- 뷰 자체에는 RLS를 직접 적용할 수 없지만, 
+-- 기본 테이블(subscriptions)에 이미 RLS가 설정되어 있으므로
+-- 뷰를 통한 접근도 자동으로 제한됩니다.
+
+-- =====================================================
+-- 4. 권한 설정
+-- =====================================================
+
+-- anon 역할에서 뷰 접근 권한 제거
+REVOKE ALL ON public.user_subscription_stats FROM anon;
+REVOKE ALL ON public.user_subscription_summary FROM anon;
+
+-- authenticated 역할에만 SELECT 권한 부여
+GRANT SELECT ON public.user_subscription_stats TO authenticated;
+GRANT SELECT ON public.user_subscription_summary TO authenticated;
+
+-- =====================================================
+-- 5. 추가 보안 함수 생성
+-- =====================================================
+
+-- 현재 사용자의 구독 통계만 반환하는 안전한 함수
+CREATE OR REPLACE FUNCTION get_my_subscription_stats()
+RETURNS TABLE (
+  total_subscriptions BIGINT,
+  active_subscriptions BIGINT,
+  paused_subscriptions BIGINT,
+  cancelled_subscriptions BIGINT,
+  total_monthly_krw NUMERIC,
+  last_updated TIMESTAMPTZ
+) 
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 현재 인증된 사용자의 ID 확인
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  SELECT 
+    uss.total_subscriptions,
+    uss.active_subscriptions,
+    uss.paused_subscriptions,
+    uss.cancelled_subscriptions,
+    uss.total_monthly_krw,
+    uss.last_updated
+  FROM public.user_subscription_stats uss
+  WHERE uss.user_id = auth.uid();
+END;
+$$;
+
+-- 현재 사용자의 구독 요약만 반환하는 안전한 함수
+CREATE OR REPLACE FUNCTION get_my_subscription_summary()
+RETURNS TABLE (
+  subscription_count BIGINT,
+  active_count BIGINT,
+  paused_count BIGINT,
+  cancelled_count BIGINT,
+  total_monthly_krw NUMERIC,
+  avg_monthly_krw NUMERIC,
+  category_count BIGINT,
+  monthly_subscriptions BIGINT,
+  yearly_subscriptions BIGINT,
+  onetime_subscriptions BIGINT,
+  krw_subscriptions BIGINT,
+  usd_subscriptions BIGINT,
+  first_subscription_date TIMESTAMPTZ,
+  last_subscription_date TIMESTAMPTZ,
+  last_updated TIMESTAMPTZ
+) 
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- 현재 인증된 사용자의 ID 확인
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  SELECT 
+    uss.subscription_count,
+    uss.active_count,
+    uss.paused_count,
+    uss.cancelled_count,
+    uss.total_monthly_krw,
+    uss.avg_monthly_krw,
+    uss.category_count,
+    uss.monthly_subscriptions,
+    uss.yearly_subscriptions,
+    uss.onetime_subscriptions,
+    uss.krw_subscriptions,
+    uss.usd_subscriptions,
+    uss.first_subscription_date,
+    uss.last_subscription_date,
+    uss.last_updated
+  FROM public.user_subscription_summary uss
+  WHERE uss.user_id = auth.uid();
+END;
+$$;
+
+-- =====================================================
+-- 6. 함수 권한 설정
+-- =====================================================
+
+-- anon 역할에서 함수 실행 권한 제거
+REVOKE ALL ON FUNCTION get_my_subscription_stats() FROM anon;
+REVOKE ALL ON FUNCTION get_my_subscription_summary() FROM anon;
+
+-- authenticated 역할에만 함수 실행 권한 부여
+GRANT EXECUTE ON FUNCTION get_my_subscription_stats() TO authenticated;
+GRANT EXECUTE ON FUNCTION get_my_subscription_summary() TO authenticated;
+
+-- =====================================================
+-- 완료 메시지
+-- =====================================================
+SELECT 'Security issues fixed successfully!' as status,
+       'Views recreated without SECURITY DEFINER' as user_subscription_stats_fix,
+       'auth.users exposure removed' as auth_users_fix,
+       'Safe functions created for authenticated users only' as additional_security;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance database security by fixing `auth.users` exposure and `SECURITY DEFINER` issues in views.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `user_subscription_summary` view was exposing `auth.users` data to anonymous roles, and both `user_subscription_summary` and `user_subscription_stats` views were defined with `SECURITY DEFINER`, which bypasses Row Level Security (RLS). This PR recreates these views to remove the `SECURITY DEFINER` property and prevent `auth.users` exposure. It also introduces secure PL/pgSQL functions (`get_my_subscription_stats`, `get_my_subscription_summary`) that enforce authentication and RLS, ensuring users can only access their own data. A `SECURITY_FIXES.md` guide is included for deployment and application code updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-c846893a-c2f8-4624-9e9f-e6573c84e167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c846893a-c2f8-4624-9e9f-e6573c84e167">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>