### PR TITLE
Fix lucide-react refresh import error

### DIFF
--- a/components/RLSDebugger.tsx
+++ b/components/RLSDebugger.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Shield, User, Database, CheckCircle, XCircle, AlertTriangle, Refresh, Play, FileText } from 'lucide-react';
+import { Shield, User, Database, CheckCircle, XCircle, AlertTriangle, RotateCw, Play, FileText } from 'lucide-react';
 import { supabase } from '../utils/supabase/client';
 import { 
   checkAuthenticationStatus, 
@@ -172,7 +172,7 @@ export const RLSDebugger: React.FC = () => {
                 disabled={isRefreshing}
                 className="flex items-center px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
               >
-                <Refresh className={`w-4 h-4 mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
+                <RotateCw className={`w-4 h-4 mr-1 ${isRefreshing ? 'animate-spin' : ''}`} />
                 새로고침
               </button>
               <button


### PR DESCRIPTION
Replace non-existent `Refresh` icon with `RotateCw` to fix build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0aa73906-3347-4237-94ce-fbe313ed55b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0aa73906-3347-4237-94ce-fbe313ed55b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>