### PR TITLE
Fix vite build crypto hash error

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -206,7 +206,6 @@ export default {
     require("@tailwindcss/forms"),
     require("@tailwindcss/typography"),
     require("@tailwindcss/aspect-ratio"),
-    require("@tailwindcss/line-clamp"),
     // Tailwind CSS Plus - Custom Plugin for Korean Typography
     function({ addUtilities, theme }) {
       const newUtilities = {


### PR DESCRIPTION
Remove `@tailwindcss/line-clamp` plugin to resolve a build warning.

The `@tailwindcss/line-clamp` plugin is now included by default in Tailwind CSS v3.3 and above, making the explicit import redundant and causing a build warning. This change was part of a larger effort to fix a `crypto.hash is not a function` error during `npm run build` by updating Vite.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dded7a4-acf1-4614-b5f4-566a162a2c7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4dded7a4-acf1-4614-b5f4-566a162a2c7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>