### PR TITLE
Fix vite build crypto hash error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "tailwindcss": "^3.4.17",
         "terser": "^5.43.1",
         "typescript": "^5.9.2",
-        "vite": "^7.0.0",
+        "vite": "^7.0.6",
         "webpack-bundle-analyzer": "^4.10.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "tailwindcss": "^3.4.17",
     "terser": "^5.43.1",
     "typescript": "^5.9.2",
-    "vite": "^7.0.0",
+    "vite": "^7.0.6",
     "webpack-bundle-analyzer": "^4.10.2"
   }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Vite to fix build error with Node.js 22.x.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `crypto.hash is not a function` error occurred because Vite 7.0.0 was incompatible with Node.js 22.x due to changes in Node.js's crypto API. Updating Vite to 7.0.6 resolves this compatibility issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7032c8d-9b72-419a-933c-fef49fed8b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7032c8d-9b72-419a-933c-fef49fed8b9f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>