### PR TITLE
Fix missing build:prod script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "preview": "vite preview",
+    "build": "vite build",
+    "build:prod": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "setup-env": "node setup-env.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,6 +98,8 @@ export default defineConfig(({ command, mode }) => {
     }
   }
 
+  // Set base path for production builds
+  if (isProduction) {
     config.base = '/'
   }
 


### PR DESCRIPTION
Add missing `build` scripts and fix a syntax error in `vite.config.ts` to enable production builds.

The `vite.config.ts` file contained an incomplete conditional block around the `config.base` setting, which caused a syntax error and prevented the project from building successfully. This PR completes the conditional to ensure `config.base` is set correctly only for production builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-2dabe237-aba1-4741-9ce9-bf4f8ed8f45f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2dabe237-aba1-4741-9ce9-bf4f8ed8f45f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>