### PR TITLE
Fix login page not appearing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -63,6 +63,7 @@ import {
 // Supabase 테스트 도구 (개발 모드에서만) - 사용되지 않으므로 주석 처리
 // Firebase auth and data hooks
 import { useFirebaseAuth } from './hooks/useFirebaseAuth';
+import { useAuth } from './contexts/AuthContext';
 
 // Types
 export interface Subscription {
@@ -404,9 +405,20 @@ function AppProvider({ children }: { children: ReactNode }) {
     }
   });
 
+  // Firebase Auth 상태를 가져오기 위해 useAuth 훅 사용
+  const { isAuthenticated: firebaseIsAuthenticated, loading: firebaseLoading } = useAuth();
+
   // Initialize authentication state
   useEffect(() => {
     console.log('🔄 App: initializeAuth useEffect 시작');
+    console.log('🔍 Firebase Auth 상태:', { firebaseIsAuthenticated, firebaseLoading });
+    
+    // Firebase Auth가 아직 로딩 중이면 대기
+    if (firebaseLoading) {
+      console.log('⏳ Firebase Auth 로딩 중, 대기...');
+      return;
+    }
+    
     const initializeAuth = async () => {
       try {
         console.log('🔍 App: getSession 호출 중...');
@@ -1238,8 +1250,8 @@ function AppProvider({ children }: { children: ReactNode }) {
       preferences,
       notifications,
       categories,
-      isAuthenticated: !!user,
-      isLoading,
+      isAuthenticated: firebaseIsAuthenticated,
+      isLoading: isLoading || firebaseLoading,
       stats,
       login,
       loginWithGoogle,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Synchronize AppProvider's authentication state with Firebase Auth to correctly display the login page.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `AppProvider`'s authentication check (`initializeAuth`) was executing before Firebase Auth had fully initialized, leading to `auth.currentUser` being `null` and an incorrect redirect to the login page or a stuck loading state. This change ensures the app waits for Firebase Auth to be ready before determining the authentication status.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a03e34b-22f5-4832-ad55-60a9221a90cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a03e34b-22f5-4832-ad55-60a9221a90cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>