### PR TITLE
Retry firestore connection

### DIFF
--- a/components/FirebaseDiagnostic.tsx
+++ b/components/FirebaseDiagnostic.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect } from 'react';
+import { checkFirebaseConnection, checkAuthStatus } from '../utils/firebase/config';
+import { db, auth } from '../utils/firebase/config';
+
+interface DiagnosticResult {
+  firebaseConfig: boolean;
+  firebaseConnection: boolean;
+  authStatus: boolean;
+  userAuthenticated: boolean;
+  errors: string[];
+}
+
+export const FirebaseDiagnostic: React.FC = () => {
+  const [diagnostic, setDiagnostic] = useState<DiagnosticResult>({
+    firebaseConfig: false,
+    firebaseConnection: false,
+    authStatus: false,
+    userAuthenticated: false,
+    errors: []
+  });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const runDiagnostic = async () => {
+      const errors: string[] = [];
+      
+      // 1. Firebase 설정 확인
+      const hasFirebaseConfig = !!(db && auth);
+      if (!hasFirebaseConfig) {
+        errors.push('Firebase 설정이 없습니다. .env 파일을 확인하세요.');
+      }
+
+      // 2. Firebase 연결 확인
+      let firebaseConnected = false;
+      if (hasFirebaseConfig) {
+        try {
+          const connectionResult = await checkFirebaseConnection();
+          firebaseConnected = connectionResult.connected;
+          if (!connectionResult.connected) {
+            errors.push(`Firebase 연결 실패: ${connectionResult.error}`);
+          }
+        } catch (error) {
+          errors.push(`Firebase 연결 확인 중 오류: ${error}`);
+        }
+      }
+
+      // 3. 인증 상태 확인
+      let authWorking = false;
+      let userAuth = false;
+      if (hasFirebaseConfig) {
+        try {
+          const authResult = await checkAuthStatus();
+          authWorking = true;
+          userAuth = authResult.isAuthenticated;
+          if (!authResult.isAuthenticated && authResult.error) {
+            errors.push(`인증 상태 확인 실패: ${authResult.error}`);
+          }
+        } catch (error) {
+          errors.push(`인증 상태 확인 중 오류: ${error}`);
+        }
+      }
+
+      setDiagnostic({
+        firebaseConfig: hasFirebaseConfig,
+        firebaseConnection: firebaseConnected,
+        authStatus: authWorking,
+        userAuthenticated: userAuth,
+        errors
+      });
+      setLoading(false);
+    };
+
+    runDiagnostic();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="flex items-center space-x-2">
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-600"></div>
+          <span className="text-blue-800">Firebase 진단 중...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+      <h3 className="text-lg font-semibold mb-4">Firebase 진단 결과</h3>
+      
+      <div className="space-y-3">
+        <div className="flex items-center space-x-2">
+          <div className={`w-3 h-3 rounded-full ${diagnostic.firebaseConfig ? 'bg-green-500' : 'bg-red-500'}`}></div>
+          <span>Firebase 설정: {diagnostic.firebaseConfig ? '✅ 정상' : '❌ 문제'}</span>
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          <div className={`w-3 h-3 rounded-full ${diagnostic.firebaseConnection ? 'bg-green-500' : 'bg-red-500'}`}></div>
+          <span>Firebase 연결: {diagnostic.firebaseConnection ? '✅ 정상' : '❌ 문제'}</span>
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          <div className={`w-3 h-3 rounded-full ${diagnostic.authStatus ? 'bg-green-500' : 'bg-red-500'}`}></div>
+          <span>인증 시스템: {diagnostic.authStatus ? '✅ 정상' : '❌ 문제'}</span>
+        </div>
+        
+        <div className="flex items-center space-x-2">
+          <div className={`w-3 h-3 rounded-full ${diagnostic.userAuthenticated ? 'bg-green-500' : 'bg-yellow-500'}`}></div>
+          <span>사용자 인증: {diagnostic.userAuthenticated ? '✅ 로그인됨' : '⚠️ 로그인 필요'}</span>
+        </div>
+      </div>
+
+      {diagnostic.errors.length > 0 && (
+        <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <h4 className="font-semibold text-red-800 mb-2">발견된 문제들:</h4>
+          <ul className="space-y-1">
+            {diagnostic.errors.map((error, index) => (
+              <li key={index} className="text-red-700 text-sm">• {error}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {diagnostic.errors.length === 0 && (
+        <div className="mt-4 p-3 bg-green-50 border border-green-200 rounded-lg">
+          <p className="text-green-800">✅ 모든 Firebase 설정이 정상입니다!</p>
+        </div>
+      )}
+
+      <div className="mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+        <h4 className="font-semibold text-blue-800 mb-2">문제 해결 방법:</h4>
+        <ul className="space-y-1 text-sm text-blue-700">
+          <li>• Firebase 콘솔에서 프로젝트 설정을 확인하세요</li>
+          <li>• .env 파일의 Firebase 환경 변수를 확인하세요</li>
+          <li>• 네트워크 연결을 확인하세요</li>
+          <li>• 브라우저 콘솔에서 더 자세한 오류를 확인하세요</li>
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/hooks/useFirestore.ts
+++ b/hooks/useFirestore.ts
@@ -28,6 +28,27 @@ const isFirebaseAvailable = () => {
   return db !== null && db !== undefined;
 };
 
+// 재시도 로직을 위한 유틸리티
+const createRetryHandler = (maxRetries = 3, baseDelay = 5000) => {
+  let retryCount = 0;
+  
+  return (error: Error, retryCallback: () => void) => {
+    if (retryCount < maxRetries) {
+      retryCount++;
+      const delay = baseDelay * Math.pow(2, retryCount - 1); // 지수 백오프
+      
+      console.log(`🔄 Firestore 연결 재시도 중... (${retryCount}/${maxRetries})`);
+      console.log(`⏰ ${delay}ms 후 재시도`);
+      
+      setTimeout(() => {
+        retryCallback();
+      }, delay);
+    } else {
+      console.error('❌ Firestore 최대 재시도 횟수 초과');
+    }
+  };
+};
+
 export const useCollection = <T = DocumentData>(
   collectionName: string, 
   constraints?: QueryConstraint[]
@@ -35,6 +56,7 @@ export const useCollection = <T = DocumentData>(
   const [data, setData] = useState<T[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [retryHandler] = useState(() => createRetryHandler());
 
   useEffect(() => {
     if (!collectionName) {
@@ -53,52 +75,64 @@ export const useCollection = <T = DocumentData>(
 
     console.log('🔍 Firestore 컬렉션 구독 시작:', collectionName);
 
-    try {
-      const collectionRef = collection(db, collectionName);
-      const q = constraints ? query(collectionRef, ...constraints) : collectionRef;
+    let unsubscribe: (() => void) | null = null;
 
-      const unsubscribe = onSnapshot(q, 
-        (snapshot) => {
-          const docs = snapshot.docs.map(doc => ({
-            id: doc.id,
-            ...doc.data()
-          })) as T[];
-          
-          console.log('✅ Firestore 데이터 업데이트:', {
-            collection: collectionName,
-            count: docs.length
-          });
-          
-          setData(docs);
-          setLoading(false);
-          setError(null);
-        },
-        (error) => {
-          console.error('❌ Firestore 구독 오류:', error);
-          
-          // 연결 오류인 경우 재시도 로직
-          if (error.code === 'unavailable' || error.code === 'permission-denied') {
-            console.log('🔄 Firestore 연결 재시도 중...');
-            setTimeout(() => {
-              setError(null);
-              setLoading(true);
-            }, 5000); // 5초 후 재시도
-          } else {
-            setError(error);
+    const setupSubscription = () => {
+      try {
+        const collectionRef = collection(db, collectionName);
+        const q = constraints ? query(collectionRef, ...constraints) : collectionRef;
+
+        unsubscribe = onSnapshot(q, 
+          (snapshot) => {
+            const docs = snapshot.docs.map(doc => ({
+              id: doc.id,
+              ...doc.data()
+            })) as T[];
+            
+            console.log('✅ Firestore 데이터 업데이트:', {
+              collection: collectionName,
+              count: docs.length
+            });
+            
+            setData(docs);
             setLoading(false);
+            setError(null);
+          },
+          (error) => {
+            console.error('❌ Firestore 구독 오류:', {
+              code: error.code,
+              message: error.message,
+              collection: collectionName
+            });
+            
+            // 연결 오류인 경우 재시도 로직
+            if (error.code === 'unavailable' || error.code === 'permission-denied' || error.code === 'unauthenticated') {
+              retryHandler(error, () => {
+                setError(null);
+                setLoading(true);
+                setupSubscription();
+              });
+            } else {
+              setError(error);
+              setLoading(false);
+            }
           }
-        }
-      );
+        );
+      } catch (error) {
+        console.error('❌ Firestore 컬렉션 구독 실패:', error);
+        setError(error as Error);
+        setLoading(false);
+      }
+    };
 
-      return () => {
-        console.log('🔍 Firestore 컬렉션 구독 종료:', collectionName);
+    setupSubscription();
+
+    return () => {
+      console.log('🔍 Firestore 컬렉션 구독 종료:', collectionName);
+      if (unsubscribe) {
         unsubscribe();
-      };
-    } catch (error) {
-      console.error('❌ Firestore 컬렉션 구독 실패:', error);
-      setError(error as Error);
-      setLoading(false);
-    }
+      }
+    };
   }, [collectionName, JSON.stringify(constraints)]);
 
   return { data, loading, error };
@@ -111,6 +145,7 @@ export const useDocument = <T = DocumentData>(
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [retryHandler] = useState(() => createRetryHandler());
 
   useEffect(() => {
     if (!collectionName || !docId) {
@@ -129,52 +164,64 @@ export const useDocument = <T = DocumentData>(
 
     console.log('🔍 Firestore 문서 구독 시작:', `${collectionName}/${docId}`);
 
-    try {
-      const docRef = doc(db, collectionName, docId);
+    let unsubscribe: (() => void) | null = null;
 
-      const unsubscribe = onSnapshot(docRef,
-        (doc) => {
-          if (doc.exists()) {
-            const docData = {
-              id: doc.id,
-              ...doc.data()
-            } as T;
-            
-            console.log('✅ Firestore 문서 업데이트:', `${collectionName}/${docId}`);
-            setData(docData);
-          } else {
-            console.log('ℹ️ Firestore 문서 없음:', `${collectionName}/${docId}`);
-            setData(null);
-          }
-          setLoading(false);
-          setError(null);
-        },
-        (error) => {
-          console.error('❌ Firestore 문서 구독 오류:', error);
-          
-          // 연결 오류인 경우 재시도 로직
-          if (error.code === 'unavailable' || error.code === 'permission-denied') {
-            console.log('🔄 Firestore 연결 재시도 중...');
-            setTimeout(() => {
-              setError(null);
-              setLoading(true);
-            }, 5000); // 5초 후 재시도
-          } else {
-            setError(error);
+    const setupSubscription = () => {
+      try {
+        const docRef = doc(db, collectionName, docId);
+
+        unsubscribe = onSnapshot(docRef,
+          (doc) => {
+            if (doc.exists()) {
+              const docData = {
+                id: doc.id,
+                ...doc.data()
+              } as T;
+              
+              console.log('✅ Firestore 문서 업데이트:', `${collectionName}/${docId}`);
+              setData(docData);
+            } else {
+              console.log('ℹ️ Firestore 문서 없음:', `${collectionName}/${docId}`);
+              setData(null);
+            }
             setLoading(false);
+            setError(null);
+          },
+          (error) => {
+            console.error('❌ Firestore 문서 구독 오류:', {
+              code: error.code,
+              message: error.message,
+              document: `${collectionName}/${docId}`
+            });
+            
+            // 연결 오류인 경우 재시도 로직
+            if (error.code === 'unavailable' || error.code === 'permission-denied' || error.code === 'unauthenticated') {
+              retryHandler(error, () => {
+                setError(null);
+                setLoading(true);
+                setupSubscription();
+              });
+            } else {
+              setError(error);
+              setLoading(false);
+            }
           }
-        }
-      );
+        );
+      } catch (error) {
+        console.error('❌ Firestore 문서 구독 실패:', error);
+        setError(error as Error);
+        setLoading(false);
+      }
+    };
 
-      return () => {
-        console.log('🔍 Firestore 문서 구독 종료:', `${collectionName}/${docId}`);
+    setupSubscription();
+
+    return () => {
+      console.log('🔍 Firestore 문서 구독 종료:', `${collectionName}/${docId}`);
+      if (unsubscribe) {
         unsubscribe();
-      };
-    } catch (error) {
-      console.error('❌ Firestore 문서 구독 실패:', error);
-      setError(error as Error);
-      setLoading(false);
-    }
+      }
+    };
   }, [collectionName, docId]);
 
   return { data, loading, error };
@@ -225,7 +272,10 @@ export const useCollectionOnce = <T = DocumentData>(
         setLoading(false);
         setError(null);
       } catch (error) {
-        console.error('❌ Firestore 일회성 조회 실패:', error);
+        console.error('❌ Firestore 일회성 조회 실패:', {
+          error,
+          collection: collectionName
+        });
         setError(error as Error);
         setLoading(false);
       }
@@ -283,7 +333,10 @@ export const useDocumentOnce = <T = DocumentData>(
         setLoading(false);
         setError(null);
       } catch (error) {
-        console.error('❌ Firestore 문서 일회성 조회 실패:', error);
+        console.error('❌ Firestore 문서 일회성 조회 실패:', {
+          error,
+          document: `${collectionName}/${docId}`
+        });
         setError(error as Error);
         setLoading(false);
       }

--- a/utils/firebase/config.ts
+++ b/utils/firebase/config.ts
@@ -21,7 +21,8 @@ console.log('🔍 Firebase 환경 변수 확인:', {
   hasProjectId: !!firebaseConfig.projectId,
   hasStorageBucket: !!firebaseConfig.storageBucket,
   hasMessagingSenderId: !!firebaseConfig.messagingSenderId,
-  hasAppId: !!firebaseConfig.appId
+  hasAppId: !!firebaseConfig.appId,
+  isDevelopment: import.meta.env.DEV
 });
 
 // Firebase 앱 초기화 (환경 변수가 없어도 초기화 시도)
@@ -35,6 +36,10 @@ try {
   if (!firebaseConfig.apiKey || !firebaseConfig.authDomain || !firebaseConfig.projectId) {
     console.warn('⚠️ Firebase 환경 변수가 설정되지 않았습니다. Supabase를 사용합니다.');
     console.warn('Firebase 설정이 필요한 경우 .env 파일에 Firebase 환경 변수를 추가하세요.');
+    console.warn('예시:');
+    console.warn('VITE_FIREBASE_API_KEY=your_api_key');
+    console.warn('VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com');
+    console.warn('VITE_FIREBASE_PROJECT_ID=your_project_id');
     
     // 더미 설정으로 초기화 (실제 사용하지 않음)
     firebaseConfig.apiKey = 'dummy-api-key';
@@ -94,7 +99,7 @@ export const checkFirebaseConnection = async () => {
   try {
     if (!db) {
       console.log('ℹ️ Firebase가 설정되지 않았습니다.');
-      return false;
+      return { connected: false, error: 'Firebase not configured' };
     }
 
     console.log('🔍 Firebase 연결 확인 중...');
@@ -103,10 +108,10 @@ export const checkFirebaseConnection = async () => {
     const testDoc = await db.collection('test').doc('connection-test').get();
     
     console.log('✅ Firebase 연결 성공');
-    return true;
+    return { connected: true, error: null };
   } catch (error) {
     console.error('❌ Firebase 연결 오류:', error);
-    return false;
+    return { connected: false, error: error.message };
   }
 };
 
@@ -129,7 +134,7 @@ export const checkAuthStatus = async () => {
   try {
     if (!auth) {
       console.log('ℹ️ Firebase Auth가 설정되지 않았습니다.');
-      return { isAuthenticated: false, user: null, error: null };
+      return { isAuthenticated: false, user: null, error: 'Firebase Auth not configured' };
     }
 
     const user = auth.currentUser;
@@ -152,7 +157,7 @@ export const checkAuthStatus = async () => {
     };
   } catch (error) {
     console.error('❌ 인증 상태 확인 실패:', error);
-    return { isAuthenticated: false, user: null, error };
+    return { isAuthenticated: false, user: null, error: error.message };
   }
 };
 

--- a/utils/firebase/config.ts
+++ b/utils/firebase/config.ts
@@ -104,13 +104,27 @@ export const checkFirebaseConnection = async () => {
 
     console.log('🔍 Firebase 연결 확인 중...');
     
-    // Firestore 연결 테스트
-    const testDoc = await db.collection('test').doc('connection-test').get();
-    
-    console.log('✅ Firebase 연결 성공');
-    return { connected: true, error: null };
+    // Firestore 연결 테스트 - 더 안전한 방법으로 변경
+    try {
+      // 간단한 쿼리로 연결 테스트
+      const testQuery = db.collection('_test_connection').limit(1);
+      await testQuery.get();
+      
+      console.log('✅ Firebase 연결 성공');
+      return { connected: true, error: null };
+    } catch (firestoreError) {
+      // 권한 오류는 연결은 되지만 권한이 없는 경우
+      if (firestoreError.code === 'permission-denied') {
+        console.log('✅ Firebase 연결됨 (권한 없음)');
+        return { connected: true, error: 'Permission denied' };
+      }
+      
+      // 다른 오류는 연결 실패로 간주
+      console.error('❌ Firebase 연결 오류:', firestoreError);
+      return { connected: false, error: firestoreError.message };
+    }
   } catch (error) {
-    console.error('❌ Firebase 연결 오류:', error);
+    console.error('❌ Firebase 연결 확인 중 오류:', error);
     return { connected: false, error: error.message };
   }
 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Improve Firebase connection stability and debugging by adding exponential backoff retries and a diagnostic component.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original error indicated persistent Firestore connection retries. This PR addresses the issue by implementing a more resilient exponential backoff retry strategy in the Firestore hooks and introducing a dedicated diagnostic component to help users identify and troubleshoot Firebase configuration and connection problems more effectively. It also enhances error logging and provides clearer guidance for environment variable setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-390325e6-6f31-4abb-be22-9d1ea60df3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-390325e6-6f31-4abb-be22-9d1ea60df3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>