### PR TITLE
Sync vite and router base paths

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1093,9 +1093,23 @@ function AppProviderContent({ children }: { children: ReactNode }) {
 }
 
 function AppProvider({ children }: { children: ReactNode }) {
+  // Normalize runtime basename for React Router (leading slash, no trailing slash except root)
+  const normalizeRouterBasename = (input?: string): string => {
+    const fallback = import.meta.env.BASE_URL || '/'
+    let base = (input && input.trim() !== '' ? input : fallback).trim()
+    if (!base.startsWith('/')) base = `/${base}`
+    // Remove trailing slash unless the path is just '/'
+    if (base.length > 1 && base.endsWith('/')) base = base.slice(0, -1)
+    // collapse duplicate slashes
+    base = base.replace(/\/+\/+/g, '/')
+    return base === '//' ? '/' : base
+  }
+
+  const basename = normalizeRouterBasename(import.meta.env.VITE_BASE_PATH)
+
   return (
     <Router 
-      basename={import.meta.env.DEV ? '/' : '/SMS_V.3.0/'}
+      basename={basename}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <AppProviderContent>

--- a/env.example
+++ b/env.example
@@ -38,6 +38,14 @@ VITE_APP_URL=https://sub.moonwave.kr
 VITE_APP_NAME=SMS V.3.0
 VITE_APP_VERSION=3.0.0
 
+# 배포 경로 설정 (선택)
+# - 빌드 시 Vite의 base로 사용됩니다 (정적 경로). 자동으로 앞/뒤 슬래시를 표준화합니다.
+# - 런타임에서 React Router basename으로도 사용되며, 끝 슬래시는 제거됩니다.
+# - 예)
+#   VITE_BASE_PATH=/           -> 웹 루트 배포 (기본값)
+#   VITE_BASE_PATH=/SMS_V.3.0/ -> GitHub Pages 프로젝트 페이지
+VITE_BASE_PATH=/
+
 # =============================================================================
 # Development Configuration
 # =============================================================================


### PR DESCRIPTION
Unify Vite's `base` and React Router's `basename` via `VITE_BASE_PATH` to resolve deployment path issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb8c3c87-0a8e-45a9-8367-23d4ad133fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb8c3c87-0a8e-45a9-8367-23d4ad133fb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

